### PR TITLE
Make ./manage.py dbshell work

### DIFF
--- a/{{cookiecutter.project_name}}/src/Dockerfile
+++ b/{{cookiecutter.project_name}}/src/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && curl -L https://raw.githubusercontent.com/Frojd/Frojd-Django-Boilerplate/develop/config/.vimrc > ~/.vimrc
 
+RUN apt-get update && apt-get -y install postgresql
+
 RUN pip install -r requirements/$REQUIREMENTS --no-cache-dir \
     && pip install ipython
 


### PR DESCRIPTION
The apt-get install in the Dockerfile had to be on a separate
RUN line because something in the first install command effects which
packages the apt-get update fetch. (postgresql is not available)